### PR TITLE
142 limit vtk version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-ver: [3.6, 3.7]
         experimental: [false]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - python-ver: 3.8
             os: windows-latest
             experimental: true
+          - python-ver: 3.8
+            os: macos-latest
+            experimental: true
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 # doc/requirements.rst
 six>=1.10
 numpy>=1.11
-vtk>=8.1.2
-PySide2<=5.14.2.1
+vtk<9.0.0
+PySide2<=5.12.0
 opencv-contrib-python>=4.1.1.26
 scikit-surgerycore>=0.1.7
 scikit-surgeryimage>=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setup(
     install_requires=[
         'six>=1.10',
         'numpy>=1.11',
-        'vtk>=8.1.2',
-        'PySide2<=5.14.2.1',
+        'vtk<9.0.0',
+        'PySide2<=5.12.0',
         'opencv-contrib-python>=4.1.1.26',
         'scikit-surgerycore>=0.1.7',
         'scikit-surgeryimage>=0.2.0',

--- a/tests/models/test_vtk_surface_model.py
+++ b/tests/models/test_vtk_surface_model.py
@@ -270,7 +270,7 @@ def test_set_texture_regression(vtk_overlay_with_gradient_image):
         pytest.skip("Test not working on Mac runner \
                     because the widget size is different")
 
-    if in_gitlab_ci and sys.platform.startswith("linux"):
+    if in_github_ci and sys.platform.startswith("linux"):
         pytest.skip("Test not working on Linux runner \
                     because of unknown issue, see #60.")
     

--- a/tests/models/test_vtk_surface_model.py
+++ b/tests/models/test_vtk_surface_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import pytest
 import vtk
 import numpy as np
@@ -261,11 +262,11 @@ def test_valid_unset_texture_when_called_with_none(
 def test_set_texture_regression(vtk_overlay_with_gradient_image):
 
     in_github_ci = os.environ.get('CI')
-    in_gitlab_ci = str(os.environ.get('GITLAB_CI'))
-    print("Gitlab_CI: " + in_gitlab_ci)
-    print("Github CI: " + in_github_ci)
+    in_gitlab_ci = os.environ.get('GITLAB_CI')
+    print("Gitlab_CI: " + str(in_gitlab_ci))
+    print("Github CI: " + str(in_github_ci))
 
-    if in_gitlab_ci and sys.platform == "darwin":
+    if sys.platform == "darwin":
         pytest.skip("Test not working on Mac runner \
                     because the widget size is different")
 
@@ -294,8 +295,12 @@ def test_set_texture_regression(vtk_overlay_with_gradient_image):
 
     current_scene = widget.convert_scene_to_numpy_array()
 
-    cv2.imwrite('screenshot.png', screenshot)
-    cv2.imwrite('current_scene.png', current_scene)
+    tmp_dir = 'tests/output'
+    if not os.path.isdir(tmp_dir):
+        os.makedirs(tmp_dir)
+    cv2.imwrite(os.path.join(tmp_dir, 'screenshot.png'), screenshot)
+    cv2.imwrite(os.path.join(tmp_dir, 'current_scene.png'), current_scene)
+
     # As the rendered images in Ubuntu, Mac and Windows are different,
     # i.e., the pixel values are slightly different at the same location,
     # we add some threshold for comparison.


### PR DESCRIPTION
Need to sort out VTK and PySide2 versions and standardise, as its bit of a mess.

Also, fixed various bugs in unit tests. Im assuming the texture_mapping one not meant to run on Mac at all, or Linux on github now.
