### PR TITLE
167 render masks with shading arg

### DIFF
--- a/tests/widgets/test_rendering_generator.py
+++ b/tests/widgets/test_rendering_generator.py
@@ -157,7 +157,7 @@ def test_mask_generator_w_shading(setup_vtk_offscreen):
     # Change shading to test same mask rendered
     models = generator.model_loader.get_surface_models()
     for model in models:
-        model.set_no_shading(True)
+        model.set_no_shading(False)
 
     # As input data could have origin anywhere, work out mean of point cloud.
     points = generator.model_loader.get_surface_model('liver50').get_points_as_numpy()

--- a/tests/widgets/test_rendering_generator.py
+++ b/tests/widgets/test_rendering_generator.py
@@ -131,3 +131,58 @@ def test_mask_generator(setup_vtk_offscreen):
         ssd = np.sum(sqdiff)
         assert ssd < 240000
 
+def test_mask_generator_w_shading(setup_vtk_offscreen):
+
+    _, _, app = setup_vtk_offscreen
+
+    model_to_world = [0, 0, 0, 0, 0, 0]
+    camera_to_world = [0, 0, 0, 0, 0, 0]
+    left_to_right = [0, 0, 0, 0, 0, 0]
+
+    model_file = "tests/data/config/surface_model_two_livers_no_shading.json"
+    background_file = "tests/data/rendering/background-960-x-540.png"
+    intrinsics_file = "tests/data/liver/calib.left.intrinsics.halved.txt"
+
+    generator = rg.VTKRenderingGenerator(model_file,
+                                         background_file,
+                                         intrinsics_file,
+                                         camera_to_world,
+                                         left_to_right,
+                                         zbuffer=False
+                                         )
+
+    generator.set_all_model_to_world(model_to_world)
+    generator.setFixedSize(960, 540)
+    generator.show()
+    # Change shading to test same mask rendered
+    models = generator.model_loader.get_surface_models()
+    for model in models:
+        model.set_no_shading(True)
+
+    # As input data could have origin anywhere, work out mean of point cloud.
+    points = generator.model_loader.get_surface_model('liver50').get_points_as_numpy()
+    mean = np.mean(points, axis=0)
+
+    # Then put model in line with camera, some distance away along z-axis.
+    model_to_world = [0, 0, 0, -mean[0], -mean[1], -mean[2] + 200]
+    generator.set_all_model_to_world(model_to_world)
+
+    # Then, as we have 2 livers the same, offset them, so we see two livers.
+    dict_of_transforms = {'liver50': [0, 0, 0, -mean[0] - 50, -mean[1] - 10, -mean[2] + 210],
+                          'liver127': [0, 0, 0, -mean[0] + 50, -mean[1] + 10, -mean[2] + 200]}
+    generator.set_model_to_worlds(dict_of_transforms)
+
+    # Save all masks for debugging, and do regression test against no shading model test data.
+    masks = generator.get_masks()
+    for name in masks.keys():
+        mask = masks[name]
+        file_name = 'rendering-liver-mask-shaded-' + name + '.png'
+        file_name_regress = 'rendering-liver-mask-' + name + '.png'
+
+        ref_img_name = os.path.join('tests/data/rendering', file_name_regress)
+        ref_img = cv2.cvtColor(cv2.imread(ref_img_name), cv2.COLOR_BGR2GRAY)
+
+        diff = mask - ref_img
+        sqdiff = diff * diff
+        ssd = np.sum(sqdiff)
+        assert ssd < 240000


### PR DESCRIPTION
# PR description

Bugfix: changed the behaviour of the get_masks() in VTKRenderingGenerator (/widgets/vtk_rendering_generator) to accommodate for shaded rendering - previously the masks obtained were not representative of the surfaces from models. Now, if models are shaded, changes the setting to no shading, get masks, and turn rendering back on.